### PR TITLE
Add deep sea boosts

### DIFF
--- a/src/main/java/net/botwithus/skilling/fishing/deepsea/DeepSeaFishWithUs.java
+++ b/src/main/java/net/botwithus/skilling/fishing/deepsea/DeepSeaFishWithUs.java
@@ -328,44 +328,48 @@ public class DeepSeaFishWithUs extends LoopingScript {
     }
 
     public long handleBoosts() {
-        String[] boosts = { "Broken fishing rod", "Barrel of bait", "Message in a bottle", "Tangled fishbowl" };
-        if (Backpack.contains(boosts)) {
-            println("A deepsea boost was found, continuing.");
-            ResultSet<Item> buff = InventoryItemQuery.newQuery(93).name(boosts).option("Interact").results();
-            Execution.delay(rand.nextLong(600, 1100));
-            if (buff != null) {
-                for (Item item : buff) {
-                    println("Found item: " + item.getName());
-                    Backpack.interact(item.getName(), "Interact");
-                    if (item.getId() == 42282) {
-                        println("Is a message in a bottle: true");
-                        Execution.delayUntil(7000, () -> Interfaces.isOpen(1186));
-                        Execution.delay(rand.nextLong(650, 750));
-                        MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 77725704);
-                        Execution.delayUntil(7000, () -> Interfaces.isOpen(751));
-                        switch (selectedBoost) {
-                            case INCREASE_CATCH_RATE:
-                                println("10% increase to catch rate");
-                                MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217586);
-                                break;
-                            case ADDITIONAL_CATCH:
-                                println("10% change to gain an additional catch");
-                                MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217594); //
-                                break;
-                            case ADDITIONAL_XP:
-                                println("5% XP increase");
-                                MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217602); //
-                                break;
+        if (claimBoosts.get()) {
+            String[] boosts = { "Broken fishing rod", "Barrel of bait", "Message in a bottle", "Tangled fishbowl" };
+            if (Backpack.contains(boosts)) {
+                println("A deepsea boost was found, continuing.");
+                ResultSet<Item> buff = InventoryItemQuery.newQuery(93).name(boosts).option("Interact").results();
+                Execution.delay(rand.nextLong(600, 1100));
+                if (buff != null) {
+                    for (Item item : buff) {
+                        println("Found item: " + item.getName());
+                        Backpack.interact(item.getName(), "Interact");
+                        if (item.getId() == 42282) {
+                            println("Is a message in a bottle: true");
+                            Execution.delayUntil(7000, () -> Interfaces.isOpen(1186));
+                            Execution.delay(rand.nextLong(650, 750));
+                            MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 77725704);
+                            Execution.delayUntil(7000, () -> Interfaces.isOpen(751));
+                            switch (selectedBoost) {
+                                case INCREASE_CATCH_RATE:
+                                    println("10% increase to catch rate");
+                                    MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217586);
+                                    break;
+                                case ADDITIONAL_CATCH:
+                                    println("10% change to gain an additional catch");
+                                    MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217594); //
+                                    break;
+                                case ADDITIONAL_XP:
+                                    println("5% XP increase");
+                                    MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217602); //
+                                    break;
+                            }
+                        } else {
+                            Execution.delayUntil(7000, () -> Interfaces.isOpen(847));
+                            MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 55509014);
+                            Execution.delayUntil(7000, () -> !Interfaces.isOpen(847));
                         }
-                    } else {
-                        Execution.delayUntil(7000, () -> Interfaces.isOpen(847));
-                        MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 55509014);
-                        Execution.delayUntil(7000, () -> !Interfaces.isOpen(847));
                     }
+                    Execution.delay(rand.nextLong(2100, 2600));
                 }
-                Execution.delay(rand.nextLong(2100, 2600));
-            }
-            return rand.nextLong(1800, 2250);
+                return rand.nextLong(1800, 2250);
+            } else {
+                return rand.nextLong(100, 250);
+            }    
         } else {
             return rand.nextLong(100, 250);
         }

--- a/src/main/java/net/botwithus/skilling/fishing/deepsea/DeepSeaFishWithUs.java
+++ b/src/main/java/net/botwithus/skilling/fishing/deepsea/DeepSeaFishWithUs.java
@@ -4,22 +4,28 @@ import net.botwithus.api.game.hud.inventories.Backpack;
 import net.botwithus.internal.scripts.ScriptDefinition;
 import net.botwithus.rs3.events.impl.SkillUpdateEvent;
 import net.botwithus.rs3.game.Client;
+import net.botwithus.rs3.game.Item;
 import net.botwithus.rs3.game.hud.interfaces.Component;
 import net.botwithus.rs3.game.hud.interfaces.Interfaces;
 import net.botwithus.rs3.game.minimenu.MiniMenu;
 import net.botwithus.rs3.game.minimenu.actions.ComponentAction;
 import net.botwithus.rs3.game.queries.builders.characters.NpcQuery;
 import net.botwithus.rs3.game.queries.builders.components.ComponentQuery;
+import net.botwithus.rs3.game.queries.builders.items.InventoryItemQuery;
 import net.botwithus.rs3.game.queries.builders.objects.SceneObjectQuery;
+import net.botwithus.rs3.game.queries.results.EntityResultSet;
+import net.botwithus.rs3.game.queries.results.ResultSet;
 import net.botwithus.rs3.game.scene.entities.characters.npc.Npc;
 import net.botwithus.rs3.game.scene.entities.characters.player.Player;
 import net.botwithus.rs3.game.scene.entities.object.SceneObject;
 import net.botwithus.rs3.game.skills.Skills;
 import net.botwithus.rs3.imgui.NativeBoolean;
 import net.botwithus.rs3.imgui.NativeInteger;
+import net.botwithus.rs3.script.Execution;
 import net.botwithus.rs3.script.LoopingScript;
 import net.botwithus.rs3.script.config.ScriptConfig;
 import net.botwithus.skilling.fishing.deepsea.enums.DeepSeaFisherBotState;
+import net.botwithus.skilling.fishing.deepsea.enums.DeepSeaBoost;
 import net.botwithus.skilling.fishing.deepsea.enums.FishingActivity;
 import net.botwithus.skilling.fishing.deepsea.enums.Jellyfish;
 import net.botwithus.skilling.fishing.deepsea.enums.MinnowBait;
@@ -36,8 +42,11 @@ public class DeepSeaFishWithUs extends LoopingScript {
     private Random rand;
     private DeepSeaFisherBotState botState = DeepSeaFisherBotState.IDLE;
     public NativeBoolean debugMode = new NativeBoolean(false);
+    public NativeBoolean claimBoosts = new NativeBoolean(false);
     public NativeInteger fishingActivity = new NativeInteger(0);
     public FishingActivity selectedActivity = FishingActivity.MINNOW;
+    public NativeInteger boostActivity = new NativeInteger(0);
+    public DeepSeaBoost selectedBoost = DeepSeaBoost.ADDITIONAL_XP;
     public NativeInteger baitType = new NativeInteger(0);
     public MinnowBait selectedBait = MinnowBait.SEA_TURTLE;
     public NativeInteger magicalBaitType = new NativeInteger(0);
@@ -47,6 +56,7 @@ public class DeepSeaFishWithUs extends LoopingScript {
     public NativeBoolean turnMinnowIntoBait = new NativeBoolean(false);
     private int animationDeadCount = 0;
     public Long startTime;
+
     public DeepSeaFishWithUs(String name, ScriptConfig scriptConfig, ScriptDefinition scriptDefinition) {
         super(name, scriptConfig, scriptDefinition);
     }
@@ -76,7 +86,8 @@ public class DeepSeaFishWithUs extends LoopingScript {
     @Override
     public void onLoop() {
         Player player = Client.getLocalPlayer();
-        if (player == null || botState == DeepSeaFisherBotState.IDLE || Client.getGameState() != Client.GameState.LOGGED_IN) {
+        if (player == null || botState == DeepSeaFisherBotState.IDLE
+                || Client.getGameState() != Client.GameState.LOGGED_IN) {
             delay(5000);
             return;
         }
@@ -95,9 +106,10 @@ public class DeepSeaFishWithUs extends LoopingScript {
             return rand.nextInt(1250, 3425);
         SimulateRandomAfk();
         if (Backpack.isFull()) {
-            SceneObject bank = SceneObjectQuery.newQuery().name("Rowboat", "Magical net", "Bank boat").option("Deposit all fish").results().nearest();
+            SceneObject bank = SceneObjectQuery.newQuery().name("Rowboat", "Magical net", "Bank boat")
+                    .option("Deposit all fish").results().nearest();
             if (selectedActivity == FishingActivity.SAILFISH) {
-                //dumb workaround since sailfish can think the entrace boat is closer.
+                // dumb workaround since sailfish can think the entrace boat is closer.
                 bank = SceneObjectQuery.newQuery().name("Magical net").option("Deposit all fish").results().nearest();
             }
             if (bank != null)
@@ -105,7 +117,7 @@ public class DeepSeaFishWithUs extends LoopingScript {
         } else {
             botState = DeepSeaFisherBotState.FISHING;
         }
-        return rand.nextInt(945,1668);
+        return rand.nextInt(945, 1668);
     }
 
     public int handleFishing(Player player) {
@@ -120,13 +132,14 @@ public class DeepSeaFishWithUs extends LoopingScript {
     }
 
     public int handleCatchingMinnow(Player player) {
+        Execution.delay(handleBoosts());
         if (player.isMoving() || player.getAnimationId() != -1)
             animationDeadCount = 0;
         if (player.getAnimationId() == -1 && animationDeadCount > 2) {
             animationDeadCount = 0;
         } else {
             animationDeadCount++;
-            return rand.nextInt(450,710);
+            return rand.nextInt(450, 710);
         }
         SimulateRandomAfk();
         int minnowCount = Backpack.getQuantity(Pattern.compile("Magnetic minnow"));
@@ -134,30 +147,34 @@ public class DeepSeaFishWithUs extends LoopingScript {
             if (Interfaces.isOpen(1370)) {
                 Component currentBait = ComponentQuery.newQuery(1370).item(selectedBait.getItemId()).results().first();
                 if (currentBait == null) {
-                    //todo idk wtf this is
+                    // todo idk wtf this is
                     if (selectedBait == MinnowBait.MANTA_RAY) {
-                        println("Selected bait type manta: " + MiniMenu.interact(ComponentAction.COMPONENT.getType(), 1, 5, 89849878));
-                        delay(rand.nextLong(875,1765));
+                        println("Selected bait type manta: "
+                                + MiniMenu.interact(ComponentAction.COMPONENT.getType(), 1, 5, 89849878));
+                        delay(rand.nextLong(875, 1765));
                     }
                     if (selectedBait == MinnowBait.SEA_TURTLE) {
-                        println("Selected bait type turtle: " + MiniMenu.interact(ComponentAction.COMPONENT.getType(), 1, 1, 89849878));
-                        delay(rand.nextLong(875,1765));
+                        println("Selected bait type turtle: "
+                                + MiniMenu.interact(ComponentAction.COMPONENT.getType(), 1, 1, 89849878));
+                        delay(rand.nextLong(875, 1765));
                     }
                     if (selectedBait == MinnowBait.GREAT_WHITE) {
-                        println("Selected bait type great white: " + MiniMenu.interact(ComponentAction.COMPONENT.getType(), 1, 9, 89849878));
-                        delay(rand.nextLong(875,1765));
+                        println("Selected bait type great white: "
+                                + MiniMenu.interact(ComponentAction.COMPONENT.getType(), 1, 9, 89849878));
+                        delay(rand.nextLong(875, 1765));
                     }
                 } else {
                     println(currentBait.toString());
                 }
-                println("Confirmed bait type: " + MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 89784350));
-                return rand.nextInt(1045,2345);
+                println("Confirmed bait type: "
+                        + MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 89784350));
+                return rand.nextInt(1045, 2345);
             } else {
                 Component minnow = ComponentQuery.newQuery(1473).itemName("Magnetic minnow").results().first();
                 if (minnow != null)
                     println("Interacted magnetic minnow: " + minnow.interact(2));
             }
-            return rand.nextInt(1134,1857);
+            return rand.nextInt(1134, 1857);
         } else {
             Npc minnowShoal = NpcQuery.newQuery().name("Minnow shoal").option("Catch").results().nearest();
             if (minnowShoal == null) {
@@ -167,25 +184,27 @@ public class DeepSeaFishWithUs extends LoopingScript {
                 println("Interacted minnow shoal: " + minnowShoal.interact("Catch"));
             }
         }
-        return rand.nextInt(2345,3789);
+        return rand.nextInt(2345, 3789);
     }
 
     public int handleCatchingMagical(Player player) {
+        Execution.delay(handleBoosts());
         if (player.isMoving() || player.getAnimationId() != -1)
             animationDeadCount = 0;
         if (player.getAnimationId() == -1 && animationDeadCount > 2) {
             animationDeadCount = 0;
         } else {
             animationDeadCount++;
-            return rand.nextInt(450,710);
+            return rand.nextInt(450, 710);
         }
         if (Backpack.isFull()) {
             println("Inventory is full! Banking fish.");
             botState = DeepSeaFisherBotState.BANKING;
-            return rand.nextInt(1743,4642);
+            return rand.nextInt(1743, 4642);
         }
         SimulateRandomAfk();
-        Npc fishableSpot = NpcQuery.newQuery().name(selectedMagicalBait.getNpcName()).option("Catch").results().nearest();
+        Npc fishableSpot = NpcQuery.newQuery().name(selectedMagicalBait.getNpcName()).option("Catch").results()
+                .nearest();
         if (fishableSpot == null) {
             int targetBaitCount = Backpack.getCount(selectedMagicalBait.getItemId());
             if (targetBaitCount == 0) {
@@ -193,7 +212,7 @@ public class DeepSeaFishWithUs extends LoopingScript {
                 println("Switching to minnows.");
                 selectedActivity = FishingActivity.MINNOW;
                 fishingActivity.set(selectedActivity.ordinal());
-                return rand.nextInt(985,1875);
+                return rand.nextInt(985, 1875);
             } else {
                 if (Interfaces.isOpen(720)) {
                     switch (selectedMagicalBait) {
@@ -201,61 +220,66 @@ public class DeepSeaFishWithUs extends LoopingScript {
                         case MANTA_RAY -> MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 47185940);
                         case GREAT_WHITE -> MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 47185943);
                     }
-                    return rand.nextInt(1013,2425);
+                    return rand.nextInt(1013, 2425);
                 }
             }
-            Npc magicalSpot = NpcQuery.newQuery().name("Magical fishing spot")/*.option("Throw bait")*/.results().nearest();
+            Npc magicalSpot = NpcQuery.newQuery().name("Magical fishing spot")/* .option("Throw bait") */.results()
+                    .nearest();
             if (magicalSpot != null) {
                 println("Interacted magical spot: " + magicalSpot.interact("Throw bait"));
             }
         } else {
             println("Interacted fishabble spot: " + fishableSpot.interact("Catch"));
         }
-        return rand.nextInt(2345,3754);
+        return rand.nextInt(2345, 3754);
     }
 
     public int handleCatchingSwarm(Player player) {
+        Execution.delay(handleBoosts());
         if (player.isMoving() || player.getAnimationId() != -1)
             animationDeadCount = 0;
         if (player.getAnimationId() == -1 && animationDeadCount > 2) {
             animationDeadCount = 0;
         } else {
             animationDeadCount++;
-            return rand.nextInt(450,710);
+            return rand.nextInt(450, 710);
         }
         if (Backpack.isFull()) {
             println("Inventory is full! Banking fish.");
             botState = DeepSeaFisherBotState.BANKING;
-            return rand.nextInt(1743,4642);
+            return rand.nextInt(1743, 4642);
         }
-        List<Npc> fishableSpot = NpcQuery.newQuery().name("Swarm").option("Net").results().stream().filter(npc -> npc.getCoordinate().getX() > 2094).toList();
+        List<Npc> fishableSpot = NpcQuery.newQuery().name("Swarm").option("Net").results().stream()
+                .filter(npc -> npc.getCoordinate().getX() > 2094).toList();
         int random = rand.nextInt(0, fishableSpot.size());
         fishableSpot.get(random).interact("Net");
-        return rand.nextInt(2456,4642);
+        return rand.nextInt(2456, 4642);
     }
 
     public int handleCatchingJellyfish(Player player) {
+        Execution.delay(handleBoosts());
         if (player.isMoving() || player.getAnimationId() != -1)
             animationDeadCount = 0;
         if (player.getAnimationId() == -1 && animationDeadCount > 2) {
             animationDeadCount = 0;
         } else {
             animationDeadCount++;
-            return rand.nextInt(450,710);
+            return rand.nextInt(450, 710);
         }
         if (Backpack.isFull()) {
             println("Inventory is full! Banking fish.");
             botState = DeepSeaFisherBotState.BANKING;
-            return rand.nextInt(1743,4642);
+            return rand.nextInt(1743, 4642);
         }
         Npc jelly = NpcQuery.newQuery().name(selectedJellyfish.getNpcName()).option("Catch").results().nearest();
         if (jelly != null) {
             println("Jelly interacted: " + jelly.interact("Catch"));
         }
-        return rand.nextInt(1743,4642);
+        return rand.nextInt(1743, 4642);
     }
 
     public int handleCatchingFrenzy(Player player) {
+        Execution.delay(handleBoosts());
         if (player.isMoving())
             return rand.nextInt(1432, 2453);
         if (rand.nextInt(200) == 0)
@@ -266,22 +290,23 @@ public class DeepSeaFishWithUs extends LoopingScript {
             delayUntil(3000, () -> NpcQuery.newQuery().id(fish.getId()).results().isEmpty());
             delay(rand.nextInt(35, 150));
         }
-        return rand.nextInt(125,470);
+        return rand.nextInt(125, 470);
     }
 
     public int handleCatchingSailfish(Player player) {
+        Execution.delay(handleBoosts());
         if (player.isMoving() || player.getAnimationId() != -1)
             animationDeadCount = 0;
         if (player.getAnimationId() == -1 && animationDeadCount > 2) {
             animationDeadCount = 0;
         } else {
             animationDeadCount++;
-            return rand.nextInt(450,710);
+            return rand.nextInt(450, 710);
         }
         if (Backpack.isFull()) {
             println("Inventory is full! Banking fish.");
             botState = DeepSeaFisherBotState.BANKING;
-            return rand.nextInt(1743,4642);
+            return rand.nextInt(1743, 4642);
         }
         SimulateRandomAfk();
         Npc sailfish = NpcQuery.newQuery().name("Swift sailfish").option("Catch").results().nearest();
@@ -291,8 +316,8 @@ public class DeepSeaFishWithUs extends LoopingScript {
     }
 
     void updateStats() {
-        totalFishCaughtPerHour = (int) (totalFishCaught / ((System.currentTimeMillis()-startTime) / 3600000.0));
-        xpPerHour = (int) (xpGained / ((System.currentTimeMillis()-startTime) / 3600000.0));
+        totalFishCaughtPerHour = (int) (totalFishCaught / ((System.currentTimeMillis() - startTime) / 3600000.0));
+        xpPerHour = (int) (xpGained / ((System.currentTimeMillis() - startTime) / 3600000.0));
         if (xpPerHour != 0) {
             int totalSeconds = Skills.FISHING.getExperienceToNextLevel() * 3600 / xpPerHour;
             int hours = totalSeconds / 3600;
@@ -302,14 +327,59 @@ public class DeepSeaFishWithUs extends LoopingScript {
         }
     }
 
+    public long handleBoosts() {
+        String[] boosts = { "Broken fishing rod", "Barrel of bait", "Message in a bottle", "Tangled fishbowl" };
+        if (Backpack.contains(boosts)) {
+            println("A deepsea boost was found, continuing.");
+            ResultSet<Item> buff = InventoryItemQuery.newQuery(93).name(boosts).option("Interact").results();
+            Execution.delay(rand.nextLong(600, 1100));
+            if (buff != null) {
+                for (Item item : buff) {
+                    println("Found item: " + item.getName());
+                    Backpack.interact(item.getName(), "Interact");
+                    if (item.getId() == 42282) {
+                        println("Is a message in a bottle: true");
+                        Execution.delayUntil(7000, () -> Interfaces.isOpen(1186));
+                        Execution.delay(rand.nextLong(650, 750));
+                        MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 77725704);
+                        Execution.delayUntil(7000, () -> Interfaces.isOpen(751));
+                        switch (selectedBoost) {
+                            case INCREASE_CATCH_RATE:
+                                println("10% increase to catch rate");
+                                MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217586);
+                                break;
+                            case ADDITIONAL_CATCH:
+                                println("10% change to gain an additional catch");
+                                MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217594); //
+                                break;
+                            case ADDITIONAL_XP:
+                                println("5% XP increase");
+                                MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 49217602); //
+                                break;
+                        }
+                    } else {
+                        Execution.delayUntil(7000, () -> Interfaces.isOpen(847));
+                        MiniMenu.interact(ComponentAction.DIALOGUE.getType(), 0, -1, 55509014);
+                        Execution.delayUntil(7000, () -> !Interfaces.isOpen(847));
+                    }
+                }
+                Execution.delay(rand.nextLong(2100, 2600));
+            }
+            return rand.nextLong(1800, 2250);
+        } else {
+            return rand.nextLong(100, 250);
+        }
+    }
+
     public void SimulateRandomAfk() {
-        //human will not always react right away.
+        // human will not always react right away.
         double random = rand.nextDouble();
         if (random * 100.0 > 97) {
             int milliSeconds = rand.nextInt(5000, 25000);
             if (rand.nextDouble() * 100 < 0.5)
                 milliSeconds += rand.nextInt(15000, 50000);
-            println("[DeepSeaFishWithUs] Unlucky 3% roll! Simulating human afk for " + milliSeconds / 1000 + " seconds.");
+            println("[DeepSeaFishWithUs] Unlucky 3% roll! Simulating human afk for " + milliSeconds / 1000
+                    + " seconds.");
             delay(milliSeconds);
         }
     }
@@ -317,11 +387,13 @@ public class DeepSeaFishWithUs extends LoopingScript {
     void saveConfiguration() {
         try {
             configuration.addProperty("fishingActivity", String.valueOf(selectedActivity.ordinal()));
+            configuration.addProperty("boostActivity", String.valueOf(selectedBoost.ordinal()));
             configuration.addProperty("baitType", String.valueOf(selectedBait.ordinal()));
             configuration.addProperty("magicalBaitType", String.valueOf(selectedMagicalBait.ordinal()));
             configuration.addProperty("jellyfishType", String.valueOf(selectedJellyfish.ordinal()));
             configuration.addProperty("turnMinnowIntoBait", String.valueOf(turnMinnowIntoBait.get()));
             configuration.addProperty("debugMode", String.valueOf(debugMode.get()));
+            configuration.addProperty("claimBoosts", String.valueOf(claimBoosts.get()));
             configuration.addProperty("botState", botState.name());
             configuration.save();
         } catch (Exception e) {
@@ -335,6 +407,8 @@ public class DeepSeaFishWithUs extends LoopingScript {
             botState = DeepSeaFisherBotState.valueOf(configuration.getProperty("botState"));
             selectedActivity = FishingActivity.values()[Integer.parseInt(configuration.getProperty("fishingActivity"))];
             fishingActivity = new NativeInteger(selectedActivity.ordinal());
+            selectedBoost = DeepSeaBoost.values()[Integer.parseInt(configuration.getProperty("boostActivity"))];
+            boostActivity = new NativeInteger(selectedBoost.ordinal());
             selectedBait = MinnowBait.values()[Integer.parseInt(configuration.getProperty("baitType"))];
             baitType = new NativeInteger(selectedBait.ordinal());
             selectedMagicalBait = MinnowBait.values()[Integer.parseInt(configuration.getProperty("magicalBaitType"))];
@@ -343,6 +417,7 @@ public class DeepSeaFishWithUs extends LoopingScript {
             jellyfishType = new NativeInteger(selectedJellyfish.ordinal());
             turnMinnowIntoBait.set(Boolean.parseBoolean(configuration.getProperty("turnMinnowIntoBait")));
             debugMode.set(Boolean.parseBoolean(configuration.getProperty("debugMode")));
+            claimBoosts.set(Boolean.parseBoolean(configuration.getProperty("claimBoosts")));
         } catch (Exception e) {
             println("Error loading configuration: \n" + e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
             println("This is a non-fatal error, you can ignore it.");

--- a/src/main/java/net/botwithus/skilling/fishing/deepsea/DeepSeaFisherGraphicsContext.java
+++ b/src/main/java/net/botwithus/skilling/fishing/deepsea/DeepSeaFisherGraphicsContext.java
@@ -5,6 +5,7 @@ import net.botwithus.rs3.imgui.ImGui;
 import net.botwithus.rs3.imgui.ImGuiWindowFlag;
 import net.botwithus.rs3.script.ScriptConsole;
 import net.botwithus.rs3.script.ScriptGraphicsContext;
+import net.botwithus.skilling.fishing.deepsea.enums.DeepSeaBoost;
 import net.botwithus.skilling.fishing.deepsea.enums.DeepSeaFisherBotState;
 import net.botwithus.skilling.fishing.deepsea.enums.FishingActivity;
 import net.botwithus.skilling.fishing.deepsea.enums.Jellyfish;
@@ -35,6 +36,14 @@ public class DeepSeaFisherGraphicsContext extends ScriptGraphicsContext {
                     }
                     ImGui.SameLine();
                     deepSeaFishWithUs.debugMode.set(ImGui.Checkbox("Debug mode", deepSeaFishWithUs.debugMode.get()));
+                    handleConfigChange();
+                    ImGui.SameLine();
+                    deepSeaFishWithUs.claimBoosts.set(ImGui.Checkbox("Interact with deepsea boosts", deepSeaFishWithUs.claimBoosts.get()));
+                    handleConfigChange();
+                    if (deepSeaFishWithUs.claimBoosts.get()) {
+                        ImGui.Combo("Message in a bottle option", deepSeaFishWithUs.boostActivity, DeepSeaBoost.toStringArray());
+                        deepSeaFishWithUs.selectedBoost = DeepSeaBoost.values()[deepSeaFishWithUs.boostActivity.get()];
+                    }
                     handleConfigChange();
                     ImGui.Combo("Fishing activity", deepSeaFishWithUs.fishingActivity, FishingActivity.toStringArray());
                     deepSeaFishWithUs.selectedActivity = FishingActivity.values()[deepSeaFishWithUs.fishingActivity.get()];

--- a/src/main/java/net/botwithus/skilling/fishing/deepsea/enums/DeepSeaBoost.java
+++ b/src/main/java/net/botwithus/skilling/fishing/deepsea/enums/DeepSeaBoost.java
@@ -1,0 +1,17 @@
+package net.botwithus.skilling.fishing.deepsea.enums;
+
+public enum DeepSeaBoost {
+
+    INCREASE_CATCH_RATE,
+    ADDITIONAL_CATCH,
+    ADDITIONAL_XP;
+
+    public static String[] toStringArray() {
+        int i = 0;
+        String[] activityStrings = new String[DeepSeaBoost.values().length];
+        for (DeepSeaBoost activity : DeepSeaBoost.values()) {
+            activityStrings[i++] = activity.toString();
+        }
+        return activityStrings;
+    }
+}

--- a/src/main/java/net/botwithus/skilling/fishing/deepsea/enums/FishingActivity.java
+++ b/src/main/java/net/botwithus/skilling/fishing/deepsea/enums/FishingActivity.java
@@ -17,6 +17,4 @@ public enum FishingActivity {
         }
         return activityStrings;
     }
-
-
 }


### PR DESCRIPTION
DeepSeaFishWithUs v1.1: Tired Panda
- Added support for deep sea boosts: Broken fishing rod, barrel of bait, message in a bottle and tangled fishbowl
- Added the option to select a your chosen message in a bottle boost (10% rate increase, 10% chance for additional catch or 5% XP)